### PR TITLE
Allow partials to define blocks and be compiled

### DIFF
--- a/tasks/grunt-handlebars-layouts.js
+++ b/tasks/grunt-handlebars-layouts.js
@@ -162,6 +162,7 @@ module.exports = function(grunt) {
 
         var getBlocks = function (context, name) {
             var blocks = context._blocks;
+            if (blocks === undefined) return [];
             return blocks[name] || (blocks[name] = []);
         };
 


### PR DESCRIPTION
I have an instance where I want to be able to compile partials individually. The partials declare their own blocks so that they can be extended by other partials. Currently when trying to compile partials in this way an error occurs because the context has no _blocks, this little tweak above fixes the issue.